### PR TITLE
[UIPSELAPP-14] Implement/wire up search and filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Runtime data
+compiled
 pids
 *.pid
 *.seed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * *BREAKING* migrate react-intl to v7. Refs UIPSELAPP-10.
 * *BREAKING* migrate stripes dependencies to their Sunflower versions. Refs UIPSELAPP-12.
+* Implement/wire up search and filtering. Refs UIPSELAPP-14.
 
 ## 1.1.0 (IN PROGRESS)
 

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -8,6 +8,21 @@ import View from '../View';
 const SELECTED_STATUS = 'status.selected';
 const UNSELECTED_STATUS = 'status.unselected';
 
+export const filterApplications = (applications, checkedAppIdsMap, filter, query) => {
+  if (filter === SELECTED_STATUS) {
+    return applications.filter(app => app.id in checkedAppIdsMap);
+  }
+
+  if (filter === UNSELECTED_STATUS) {
+    return applications.filter(app => !(app.id in checkedAppIdsMap));
+  }
+
+  if (query) {
+    return applications.filter(app => app.id.includes(query));
+  }
+  return applications;
+};
+
 export default function Container({
   onClose,
   onSave,
@@ -19,19 +34,7 @@ export default function Container({
   const [query, setQuery] = useState({});
 
   const querySetter = ({ nsValues }) => {
-    let filteredApplications = applicationsList;
-
-    if (nsValues.filters === SELECTED_STATUS) {
-      filteredApplications = filteredApplications.filter(app => app.id in checkedAppIdsMap);
-    }
-
-    if (nsValues.filters === UNSELECTED_STATUS) {
-      filteredApplications = filteredApplications.filter(app => !(app.id in checkedAppIdsMap));
-    }
-
-    if (nsValues.query) {
-      filteredApplications = filteredApplications.filter(app => app.id.includes(nsValues.query));
-    }
+    const filteredApplications = filterApplications(applicationsList, checkedAppIdsMap, nsValues.filters, nsValues.query);
 
     setApplications(filteredApplications);
     setQuery({ ...query, ...nsValues });
@@ -59,4 +62,7 @@ Container.propTypes = {
   checkedAppIdsMap: PropTypes.object
 };
 
-
+module.exports = {
+  Container,
+  filterApplications
+};

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -4,24 +4,7 @@ import PropTypes from 'prop-types';
 import { useStripes } from '@folio/stripes/core';
 
 import View from '../View';
-
-const SELECTED_STATUS = 'status.selected';
-const UNSELECTED_STATUS = 'status.unselected';
-
-export const filterApplications = (applications, checkedAppIdsMap, filter, query) => {
-  if (filter === SELECTED_STATUS) {
-    return applications.filter(app => app.id in checkedAppIdsMap);
-  }
-
-  if (filter === UNSELECTED_STATUS) {
-    return applications.filter(app => !(app.id in checkedAppIdsMap));
-  }
-
-  if (query) {
-    return applications.filter(app => app.id.includes(query));
-  }
-  return applications;
-};
+import { filterApplications } from '../Utils';
 
 export default function Container({
   onClose,
@@ -60,9 +43,4 @@ Container.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   checkedAppIdsMap: PropTypes.object
-};
-
-module.exports = {
-  Container,
-  filterApplications
 };

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -4,9 +4,6 @@ import PropTypes from 'prop-types';
 import { useStripes } from '@folio/stripes/core';
 
 import View from '../View';
-import { useApplications } from '../hooks/useApplications';
-
-const INITIAL_RESULT_COUNT = 0;
 
 export default function Container({
   onClose,
@@ -15,7 +12,6 @@ export default function Container({
 }) {
   const stripes = useStripes();
   const applicationsList = Object.values(stripes.discovery.applications).map(app => ({ id: app.name, name: app.name }));
-  //const { applications, isLoading, onSubmitSearch } = useApplications();
   const [applications, setApplications] = useState(applicationsList);
   const [query, setQuery] = useState({});
   const querySetter = ({ nsValues }) => {
@@ -30,7 +26,7 @@ export default function Container({
     }
 
     if (nsValues.query) {
-        filteredApplications = filteredApplications.filter(app => app.id.includes(nsValues.query));
+      filteredApplications = filteredApplications.filter(app => app.id.includes(nsValues.query));
     }
 
     setApplications(filteredApplications);
@@ -44,9 +40,9 @@ export default function Container({
       data={{
         applications
       }}
+      initialSearch=""
       onClose={onClose}
       onSave={onSave}
-      initialSearch={''}
       queryGetter={queryGetter}
       querySetter={querySetter}
     />

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -5,6 +5,9 @@ import { useStripes } from '@folio/stripes/core';
 
 import View from '../View';
 
+const SELECTED_STATUS = 'status.selected';
+const UNSELECTED_STATUS = 'status.unselected';
+
 export default function Container({
   onClose,
   onSave,
@@ -14,14 +17,15 @@ export default function Container({
   const applicationsList = Object.values(stripes.discovery.applications).map(app => ({ id: app.name, name: app.name }));
   const [applications, setApplications] = useState(applicationsList);
   const [query, setQuery] = useState({});
+
   const querySetter = ({ nsValues }) => {
     let filteredApplications = applicationsList;
 
-    if (nsValues.filters === 'status.selected') {
+    if (nsValues.filters === SELECTED_STATUS) {
       filteredApplications = filteredApplications.filter(app => app.id in checkedAppIdsMap);
     }
 
-    if (nsValues.filters === 'status.unselected') {
+    if (nsValues.filters === UNSELECTED_STATUS) {
       filteredApplications = filteredApplications.filter(app => !(app.id in checkedAppIdsMap));
     }
 

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -42,5 +42,7 @@ export default function Container({
 Container.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
-  checkedAppIdsMap: PropTypes.object
+  checkedAppIdsMap: PropTypes.shape({
+    [PropTypes.string]: PropTypes.bool
+  })
 };

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -1,7 +1,12 @@
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { useStripes } from '@folio/stripes/core';
+
 import View from '../View';
+import { useApplications } from '../hooks/useApplications';
+
+const INITIAL_RESULT_COUNT = 0;
 
 export default function Container({
   onClose,
@@ -9,17 +14,41 @@ export default function Container({
   checkedAppIdsMap
 }) {
   const stripes = useStripes();
+  const applicationsList = Object.values(stripes.discovery.applications).map(app => ({ id: app.name, name: app.name }));
+  //const { applications, isLoading, onSubmitSearch } = useApplications();
+  const [applications, setApplications] = useState(applicationsList);
+  const [query, setQuery] = useState({});
+  const querySetter = ({ nsValues }) => {
+    let filteredApplications = applicationsList;
 
-  const applications = Object.values(stripes.discovery.applications).map(app => ({ id: app.name, name: app.name }));
+    if (nsValues.filters === 'status.selected') {
+      filteredApplications = filteredApplications.filter(app => app.id in checkedAppIdsMap);
+    }
+
+    if (nsValues.filters === 'status.unselected') {
+      filteredApplications = filteredApplications.filter(app => !(app.id in checkedAppIdsMap));
+    }
+
+    if (nsValues.query) {
+        filteredApplications = filteredApplications.filter(app => app.id.includes(nsValues.query));
+    }
+
+    setApplications(filteredApplications);
+    setQuery({ ...query, ...nsValues });
+  };
+  const queryGetter = () => query;
 
   return (
     <View
       checkedAppIdsMap={checkedAppIdsMap}
       data={{
-        applications,
+        applications
       }}
       onClose={onClose}
       onSave={onSave}
+      initialSearch={''}
+      queryGetter={queryGetter}
+      querySetter={querySetter}
     />
   );
 }

--- a/src/Container/Container.test.js
+++ b/src/Container/Container.test.js
@@ -5,8 +5,7 @@ import { renderWithIntl, MultiColumnList } from '@folio/stripes-erm-testing';
 
 import translationsProperties from '../../test/helpers';
 
-import Container from './Container';
-
+import { Container, filterApplications } from './Container';
 
 jest.mock('../View', () => () => <div>View</div>);
 
@@ -26,6 +25,10 @@ jest.mock('@folio/stripes/core', () => {
 const onClose = jest.fn();
 const onSaveMock = jest.fn();
 const mockCheckedAppIdsMap = {};
+const mockApplicationsList = [
+  { id: 'app1', name: 'app1' },
+  { id: 'app2', name: 'app2' }
+];
 
 describe('Container', () => {
   let renderComponent;
@@ -57,5 +60,26 @@ describe('Container', () => {
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
+  });
+
+  it('filters applications by SELECTED_STATUS', () => {
+    const checkedAppIdsMap = { 'app1': true };
+    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, 'status.selected');
+
+    expect(filteredApplications).toEqual([{ id: 'app1', name: 'app1' }]);
+  });
+
+  it('filters applications by UNSELECTED_STATUS', () => {
+    const checkedAppIdsMap = { 'app1': true };
+    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, 'status.unselected');
+
+    expect(filteredApplications).toEqual([{ id: 'app2', name: 'app2' }]);
+  });
+
+  it('filters applications by query string', () => {
+    const checkedAppIdsMap = { 'app1': true };
+    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, '', 'app2');
+
+    expect(filteredApplications).toEqual([{ id: 'app2', name: 'app2' }]);
   });
 });

--- a/src/Container/Container.test.js
+++ b/src/Container/Container.test.js
@@ -5,7 +5,7 @@ import { renderWithIntl, MultiColumnList } from '@folio/stripes-erm-testing';
 
 import translationsProperties from '../../test/helpers';
 
-import { Container, filterApplications } from './Container';
+import Container from './Container';
 
 jest.mock('../View', () => () => <div>View</div>);
 
@@ -25,10 +25,6 @@ jest.mock('@folio/stripes/core', () => {
 const onClose = jest.fn();
 const onSaveMock = jest.fn();
 const mockCheckedAppIdsMap = {};
-const mockApplicationsList = [
-  { id: 'app1', name: 'app1' },
-  { id: 'app2', name: 'app2' }
-];
 
 describe('Container', () => {
   let renderComponent;
@@ -60,26 +56,5 @@ describe('Container', () => {
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
-  });
-
-  it('filters applications by SELECTED_STATUS', () => {
-    const checkedAppIdsMap = { 'app1': true };
-    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, 'status.selected');
-
-    expect(filteredApplications).toEqual([{ id: 'app1', name: 'app1' }]);
-  });
-
-  it('filters applications by UNSELECTED_STATUS', () => {
-    const checkedAppIdsMap = { 'app1': true };
-    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, 'status.unselected');
-
-    expect(filteredApplications).toEqual([{ id: 'app2', name: 'app2' }]);
-  });
-
-  it('filters applications by query string', () => {
-    const checkedAppIdsMap = { 'app1': true };
-    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, '', 'app2');
-
-    expect(filteredApplications).toEqual([{ id: 'app2', name: 'app2' }]);
   });
 });

--- a/src/Container/index.js
+++ b/src/Container/index.js
@@ -1,1 +1,1 @@
-export { Container, filterApplications } from './Container';
+export { default as Container, filterApplications } from './Container';

--- a/src/Container/index.js
+++ b/src/Container/index.js
@@ -1,1 +1,1 @@
-export { default as Container, filterApplications } from './Container';
+export { default } from './Container';

--- a/src/Container/index.js
+++ b/src/Container/index.js
@@ -1,1 +1,1 @@
-export { default } from './Container';
+export { Container, filterApplications } from './Container';

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Modal } from '@folio/stripes/components';
 
-import { Container } from '../Container';
+import Container from '../Container';
 
 import css from './Modal.css';
 

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Modal } from '@folio/stripes/components';
 
-import Container from '../Container';
+import { Container } from '../Container';
 
 import css from './Modal.css';
 

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -48,6 +48,8 @@ ApplicationSearchModal.propTypes = {
     connect: PropTypes.func.isRequired,
   }),
   onSave: PropTypes.func,
-  checkedAppIdsMap: PropTypes.object
+  checkedAppIdsMap: PropTypes.shape({
+    [PropTypes.string]: PropTypes.bool
+  })
 };
 

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -68,6 +68,8 @@ export default function ApplicationSearch(props) {
 ApplicationSearch.propTypes = {
   renderTrigger: PropTypes.func,
   onSave: PropTypes.func,
-  checkedAppIdsMap: PropTypes.object
+  checkedAppIdsMap: PropTypes.shape({
+    [PropTypes.string]: PropTypes.bool
+  }),
 };
 

--- a/src/Utils/Utils.js
+++ b/src/Utils/Utils.js
@@ -1,0 +1,17 @@
+const SELECTED_STATUS = 'status.selected';
+const UNSELECTED_STATUS = 'status.unselected';
+
+export const filterApplications = (applications, checkedAppIdsMap, filter, query) => {
+  if (filter === SELECTED_STATUS) {
+    return applications.filter(app => app.id in checkedAppIdsMap);
+  }
+
+  if (filter === UNSELECTED_STATUS) {
+    return applications.filter(app => !(app.id in checkedAppIdsMap));
+  }
+
+  if (query) {
+    return applications.filter(app => app.id.includes(query));
+  }
+  return applications;
+};

--- a/src/Utils/Utils.test.js
+++ b/src/Utils/Utils.test.js
@@ -1,0 +1,29 @@
+import { filterApplications } from './Utils';
+
+const mockApplicationsList = [
+  { id: 'app1', name: 'app1' },
+  { id: 'app2', name: 'app2' }
+];
+
+describe('Utils', () => {
+  it('filters applications by SELECTED_STATUS', () => {
+    const checkedAppIdsMap = { 'app1': true };
+    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, 'status.selected');
+
+    expect(filteredApplications).toEqual([{ id: 'app1', name: 'app1' }]);
+  });
+
+  it('filters applications by UNSELECTED_STATUS', () => {
+    const checkedAppIdsMap = { 'app1': true };
+    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, 'status.unselected');
+
+    expect(filteredApplications).toEqual([{ id: 'app2', name: 'app2' }]);
+  });
+
+  it('filters applications by query string', () => {
+    const checkedAppIdsMap = { 'app1': true };
+    const filteredApplications = filterApplications(mockApplicationsList, checkedAppIdsMap, '', 'app2');
+
+    expect(filteredApplications).toEqual([{ id: 'app2', name: 'app2' }]);
+  });
+});

--- a/src/Utils/index.js
+++ b/src/Utils/index.js
@@ -1,0 +1,1 @@
+export * from './Utils';

--- a/src/Utils/index.js
+++ b/src/Utils/index.js
@@ -1,1 +1,1 @@
-export * from './Utils';
+export { filterApplications } from './Utils';

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -30,7 +30,10 @@ export default function View({
   data,
   onClose,
   onSave,
-  checkedAppIdsMap
+  checkedAppIdsMap,
+  initialSearch,
+  queryGetter,
+  querySetter
 }) {
   const intl = useIntl();
 
@@ -153,6 +156,9 @@ export default function View({
       <SearchAndSortQuery
         initialFilterState={{ status: [] }}
         initialSortState={{ sort: 'name' }}
+        initialSearch={initialSearch}
+        queryGetter={queryGetter}
+        querySetter={querySetter}
       >
         {
           ({
@@ -285,6 +291,9 @@ View.propTypes = {
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
-  checkedAppIdsMap: PropTypes.object
+  checkedAppIdsMap: PropTypes.object,
+  initialSearch: PropTypes.string,
+  queryGetter: PropTypes.func,
+  querySetter: PropTypes.func
 };
 

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -291,7 +291,9 @@ View.propTypes = {
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
-  checkedAppIdsMap: PropTypes.object,
+  checkedAppIdsMap: PropTypes.shape({
+    [PropTypes.string]: PropTypes.bool
+  }),
   initialSearch: PropTypes.string,
 };
 

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -155,8 +155,8 @@ export default function View({
     <div ref={contentRef} data-testid="search-applications-testId">
       <SearchAndSortQuery
         initialFilterState={{ status: [] }}
-        initialSortState={{ sort: 'name' }}
         initialSearch={initialSearch}
+        initialSortState={{ sort: 'name' }}
         queryGetter={queryGetter}
         querySetter={querySetter}
       >
@@ -293,7 +293,5 @@ View.propTypes = {
   onSave: PropTypes.func.isRequired,
   checkedAppIdsMap: PropTypes.object,
   initialSearch: PropTypes.string,
-  queryGetter: PropTypes.func,
-  querySetter: PropTypes.func
 };
 


### PR DESCRIPTION
- Fulfills [UIPSELAPP-14](https://folio-org.atlassian.net/browse/UIPSELAPP-14).
- Added search and filter methods for Application Search, which is sourced from `/applications` call made on page load. 
- Continues to use `<SearchAndSortQuery>` component, and handles searching/filtering via `querySetter`, rather than making unnecessary additional calls to `/applications`.
- TODO: add unit test coverage, which is proving tricky ATM to access the `querySetter` function in `Container.js`.


Full List:
<img width="1102" height="551" alt="image" src="https://github.com/user-attachments/assets/e66ebaa8-5882-4df5-89e2-adb360b9e9f3" />

Filter by value:
<img width="1102" height="540" alt="image" src="https://github.com/user-attachments/assets/f59c62e9-863e-43a0-9249-66dbec51c4b8" />

Filter by saved selection status:
<img width="1102" height="540" alt="image" src="https://github.com/user-attachments/assets/182ed862-d081-4e03-b4ff-6bca029ec802" />
