### PR TITLE
[UIPSELAPP-14] Clear search term when using Reset Results control or using blank search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * *BREAKING* migrate stripes dependencies to their Sunflower versions. Refs UIPSELAPP-12.
 * Implement/wire up search and filtering. Refs UIPSELAPP-14.
 * Allow search and filtering to complement each other. Allow case-insensitve searching. Refs UIPSELAPP-14.
+* Fix bug where searching multiple times produces different search results because of React state issues. Refs UIPSELAPP-14.
 
 ## 1.1.0 (IN PROGRESS)
 

--- a/src/Container/Container.js
+++ b/src/Container/Container.js
@@ -17,10 +17,16 @@ export default function Container({
   const [query, setQuery] = useState({});
 
   const querySetter = ({ nsValues }) => {
-    const filteredApplications = filterApplications(applicationsList, checkedAppIdsMap, nsValues.filters, nsValues.query);
+    const currentQuery = { ...query, ...nsValues };
+
+    // Query and filters don't work the same way. An omitted query means reset search or filters only.
+    // Omitted filters can occur when only search term is updated (but filters were previously applied).
+    if (!nsValues.query) { currentQuery.query = undefined; }
+
+    const filteredApplications = filterApplications(applicationsList, checkedAppIdsMap, currentQuery.filters, currentQuery.query);
 
     setApplications(filteredApplications);
-    setQuery({ ...query, ...nsValues });
+    setQuery(currentQuery);
   };
   const queryGetter = () => query;
 


### PR DESCRIPTION
- Fixes issue raised by QA in https://folio-org.atlassian.net/browse/UIPSELAPP-14?focusedCommentId=273327
- This ensures that previously applied search term and filters are retained between searches. This also ensures that clearing the search term with the Reset Results button is applied correctly. Previously, the current search was not properly retaining values from the previous search making the result list visibly incorrect.
- `filters` are passed through since it is a string value that either has the filters present as comma-separated values or if cleared are an empty string. `query` is present when using a search term or is omitted if user only uses a filter or clicks the Reset Results button. `query` is set to `undefined` when resetting the search because of how javascript object copying works when setting `currentQuery` (old value is kept unless explicitly cleared).