### PR TITLE
UIPSELAPP-16 do not virtualize data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Implement/wire up search and filtering. Refs UIPSELAPP-14.
 * Allow search and filtering to complement each other. Allow case-insensitve searching. Refs UIPSELAPP-14.
 * Fix bug where searching multiple times produces different search results because of React state issues. Refs UIPSELAPP-14.
+* Do not virtualize the application-list table. Refs UIPSELAPP-16.
 
 ## 1.1.0 (IN PROGRESS)
 

--- a/src/View/View.js
+++ b/src/View/View.js
@@ -265,7 +265,6 @@ export default function View({
                     interactive={false}
                     rowFormatter={rowFormatter}
                     totalCount={data.applications.length}
-                    virtualize
                     visibleColumns={['isChecked', 'name']}
                   />
                 </Pane>


### PR DESCRIPTION
Virtualization is an optimization to facilitate display of very large datasets, on the order of thousands or tens of thousands. We don't have that kind of data here, and the tradeoffs virtualization makes WRT DOM inspection negatively impact tests (offscreen elements cannot be found) so there is no good reason to keep it.

Refs [UIPSELAPP-16](https://folio-org.atlassian.net/browse/UIPSELAPP-16)